### PR TITLE
wordsmit: creating a new file

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ For more information about configuring front matter, see the [Jekyll front matte
 
 ### :keyboard: Activity: Create a blog post
 
-1. Browse to **Files Changed** tab in the pull request from the `my-pages` branch.
-1. Click **Create new file**.
+1. Browse to the `my-pages` branch.
+1. Click the `Add file` dropdown menu and then on `Create new file`.
 1. Name the file `_posts/YYYY-MM-DD-title.md`.
 1. Replace the `YYYY-MM-DD` with today's date, and change the `title` of your first blog post if you'd like.
    > If you do edit the title, make sure there are hyphens between your words.


### PR DESCRIPTION
### Why:

I don't remember myself but seems like it used to be possible to create a new file directly from PR > Files changed but not possible as far as I can see 👓 

### What's being changed:

Instead mention to go the PR branch and create a new file from there

### Check off the following:

- [ ] n/a For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
