### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The first step is to enable GitHub Pages on this [repository](https://docs.githu
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab.
 1. Under your repository name, click **Settings**.
-1. In the "GitHub Pages" section, use the Source drop-down, then select **main branch**.
+1. Click **Pages**, In the "GitHub Pages" section, use the Source drop-down, then select **main branch**.
 1. Wait about _one minute_, then refresh this page for the next step.
    > Turning on GitHub Pages creates a deployment of your repository. I may take up to a minute to respond as I await the deployment. Future steps will be about 20 seconds; this step is slower.
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The first step is to enable GitHub Pages on this [repository](https://docs.githu
 
 1. Open a new browser tab, and work on the steps in your second tab while you read the instructions in this tab.
 1. Under your repository name, click **Settings**.
-1. Click **Pages**, In the "GitHub Pages" section, use the Source drop-down, then select **main branch**.
+1. Click **Pages**, in the "GitHub Pages" section, use the Source drop-down, then select **main branch**.
 1. Wait about _one minute_, then refresh this page for the next step.
    > Turning on GitHub Pages creates a deployment of your repository. I may take up to a minute to respond as I await the deployment. Future steps will be about 20 seconds; this step is slower.
 


### PR DESCRIPTION
### Why:

Readers can't get to the "GitHub Pages" section just by doing Click Settings.

### What's being changed:

Added "Click Pages" after "Click Settings" in Step 1.
![image](https://user-images.githubusercontent.com/52732654/172784594-2a1f7f92-20f1-45ae-ad28-2e69b8f98a90.png)

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
