### PR TITLE
Change the link to redirect to new skills page

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ With GitHub Pages, you can host project blogs, documentation, resumes, portfolio
 - **Who is this for**: Beginners, students, project maintainers, small businesses.
 - **What you'll learn**: How to build a GitHub Pages site.
 - **What you'll build**: We'll build a simple GitHub Pages site with a blog. We'll use [Jekyll](https://jekyllrb.com), a static site generator.
-- **Prerequisites**: If you need to learn about branches, commits, and pull requests, take [Introduction to GitHub](https://lab.github.com/githubtraining/introduction-to-github) first. 
+- **Prerequisites**: If you need to learn about branches, commits, and pull requests, take [Introduction to GitHub](https://github.com/skills/introduction-to-github) first.
 - **How long**: This course is five steps long and takes less than one hour to complete.
 
 ## How to start this course


### PR DESCRIPTION
### Why:

A link in README.md redirects to GitHub Learning Lab.

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->
The link now redirects to GitHub Skills Introduction to GitHub repository.
lab.github.com/githubtraining/ &rarr; github.com/skills/
Cf. [similar PR](https://github.com/skills/publish-packages/pull/5)

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [x] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
