### PR TITLE
Ask learner to create PR manually

### DIFF
--- a/.github/workflows/0-start.yml
+++ b/.github/workflows/0-start.yml
@@ -65,10 +65,6 @@ jobs:
 
           echo "Push"
           git push --set-upstream origin $BRANCH
-
-          echo "Make a pull request"
-          # Reference https://cli.github.com/manual/gh_pr_create
-          gh pr create --title "GitHub Pages" --body "GitHub Pages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ We need to use a blog-ready theme. For this activity, we will use a theme named 
     ```
 1. (optional) You can modify the other configuration variables such as `title:`, `author:`, and `description:` to further customize your site.
 1. Commit your changes.
-2. (optional) Create a pull request to view all the changes you'll make throughout this course. Click the **Pull Requests** tab, click **New pull request**, set `base: main` and `compare:my-pages`.
-3. Wait about 20 seconds then refresh this page for the next step.
+1. (optional) Create a pull request to view all the changes you'll make throughout this course. Click the **Pull Requests** tab, click **New pull request**, set `base: main` and `compare:my-pages`.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 
@@ -187,8 +187,8 @@ You can now [merge](https://docs.github.com/en/get-started/quickstart/github-glo
 ### :keyboard: Activity: Merge your changes
 
 1. Merge your changes from `my-pages` into `main`. If you created the pull request in step 2, just open that PR and click on **Merge Changes**. If you did not create the pull request earlier, you can do it now by following the instructions in step 2.
-2. (optional) Delete the branch `my-pages`.
-3. Wait about 20 seconds then refresh this page for the next step.
+1. (optional) Delete the branch `my-pages`.
+1. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ You can now [merge](https://docs.github.com/en/get-started/quickstart/github-glo
 
 ### :keyboard: Activity: Merge your changes
 
-1. Merge your changes from `my-pages` into `main`. If you created the pull request in step 2, just open that PR and click on **Merge Changes**. If you did not create the pull request earlier, you can do it now by following the instructions in step 2.
+1. Merge your changes from `my-pages` into `main`. If you created the pull request in step 2, just open that PR and click on **Merge pull request**. If you did not create the pull request earlier, you can do it now by following the instructions in step 2.
 1. (optional) Delete the branch `my-pages`.
 1. Wait about 20 seconds then refresh this page for the next step.
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ We need to use a blog-ready theme. For this activity, we will use a theme named 
     ```
 1. (optional) You can modify the other configuration variables such as `title:`, `author:`, and `description:` to further customize your site.
 1. Commit your changes.
-1. Wait about 20 seconds then refresh this page for the next step.
+2. (optional) Create a pull request to view all the changes you'll make throughout this course. Click the **Pull Requests** tab, click **New pull request**, set `base: main` and `compare:my-pages`.
+3. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 
@@ -183,11 +184,11 @@ _Nice work, friend :heart:! People will be reading your blog in no time!_
 
 You can now [merge](https://docs.github.com/en/get-started/quickstart/github-glossary#merge) your pull request!
 
-### :keyboard: Activity: Merge your pull request
+### :keyboard: Activity: Merge your changes
 
-1. Click **Merge pull request**.
-1. Delete the branch `my-pages` (optional).
-1. Wait about 20 seconds then refresh this page for the next step.
+1. Merge your changes from `my-pages` into `main`. If you created the pull request in step 2, just open that PR and click on **Merge Changes**. If you did not create the pull request earlier, you can do it now by following the instructions in step 2.
+2. (optional) Delete the branch `my-pages`.
+3. Wait about 20 seconds then refresh this page for the next step.
 
 </details>
 


### PR DESCRIPTION
### Why:

Part of https://github.com/github/skills/issues/96. 

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

The `GITHUB_TOKEN` we use in the Actions workflows [no longer allows](https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/) the creation of PRs. We're updating the course to remove any automatically-generated PRs. The learner is now asked to create any necessary PRs. 

### Check off the following:

- [x] For workflow changes, I have verified the Actions workflows function as expected.
- [ ] For content changes, I have reviewed the [style guide](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
